### PR TITLE
Use imagePullCredentials when using private docker images

### DIFF
--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
@@ -68,3 +68,7 @@ spec:
           initialDelaySeconds: 70
           periodSeconds: 20
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
@@ -72,4 +72,3 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
-      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-dashboard-deployment.yaml
@@ -72,3 +72,4 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
+      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
@@ -109,3 +109,7 @@ spec:
         persistentVolumeClaim:
           claimName: sp-mgt-volume-claim
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
@@ -113,4 +113,3 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
-      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-1-deployment.yaml
@@ -113,3 +113,4 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
+      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
@@ -109,3 +109,7 @@ spec:
         persistentVolumeClaim:
           claimName: sp-mgt-volume-claim
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
@@ -113,4 +113,3 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
-      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-manager-2-deployment.yaml
@@ -113,3 +113,4 @@ spec:
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
+      

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-receiver-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-receiver-deployment.yaml
@@ -109,6 +109,10 @@ spec:
           initialDelaySeconds: 70
           periodSeconds: 20
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}
       volumes:
       - name: sp-worker-conf
         configMap:

--- a/helm/pattern-distributed/pattern-distributed/templates/wso2sp-worker-deployment.yaml
+++ b/helm/pattern-distributed/pattern-distributed/templates/wso2sp-worker-deployment.yaml
@@ -109,6 +109,10 @@ spec:
           initialDelaySeconds: 70
           periodSeconds: 20
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}
       volumes:
       - name: sp-worker-conf
         configMap:


### PR DESCRIPTION
## Purpose
Add conditional use of imagePullCredentials when using WSO2 private docker registry in helm charts.